### PR TITLE
Enabled the A20 gate for access to all of the memory

### DIFF
--- a/src/bootloader/read_kernel.asm
+++ b/src/bootloader/read_kernel.asm
@@ -7,10 +7,9 @@ load_kernel:
     mov sp, 0x7c00
     sti
 
-
     xor ax, ax
     int 0x13
-    jc .dsk_err
+    jc dsk_err
 
     mov ax, 0x1000
     xor bx, bx
@@ -23,19 +22,42 @@ load_kernel:
     mov ch, 0
     mov dh, 0
     int 0x13
-    jc .dsk_err
+    jc dsk_err
     cmp al, 1
-    jne .dsk_err
+    jne dsk_err
 
     mov si, dsk_ok
     call printstr
-    call enable_pmode
-    call 0x1000 ;8h:0x1000
-    ret
-    ;jmp enable_pmode
 
-.dsk_err:
+    call is_A20
+    call enable_pmode
+dsk_err:
     mov si, err_msg
     call printstr
+is_A20:
+    pusha
+    mov ax, 2403h
+    int 0x15
+    jb dsk_err
+    cmp ah, 0
+    jnz dsk_err
+    mov ax, 2402h
+    int 0x15
+    jb dsk_err
+    cmp ah, 0
+    jnz dsk_err
+    cmp al, 1
+    jz A20_on
+    mov ax, 2401h
+    int 0x15
+    jb dsk_err
+    cmp ah, 0
+    jnz dsk_err
+    popa
+    ret
+A20_on:
+    call enable_pmode
+    mov word[ds:eax], 0x0f51
+    jmp $
 dsk_ok: db "Disk [Works]", 0xa, 0xd, 0
 err_msg: db "Error reading 0x1000 from disk", 0xa, 0xd, 0


### PR DESCRIPTION
Enabled the A20 gate for access to all of the memory.
Uses interrupt 0x15 before booting into 32 bit protected mode.